### PR TITLE
duplicates assemblies based on assemblies types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,6 +808,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (~> 1.4)
@@ -835,4 +836,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ You're good to go!
 
 ## The Assembly duplicator hack
 
-PR #15 introduces an experimental feature that allows to duplicate the Assembly module in the menu.
-It uses the Assemblies types to divide the assemblies assigned depending on how it is configured.
+PR #15 introduces an experimental feature that allows to add an alternative Assemblies menu.
+It uses the Assemblies types to divide the assemblies into the original and the different alternative menus.
 
 For instance, imagine you have these assembly types:
 
-- Governance [type ID: 12]
-- Participation [type ID: 17]
-- Others [type ID: 9]
+- Governance [Assembly Type ID: 12]
+- Participation [Assembly Type ID: 17]
+- Others [Assembly Type ID: 9]
 
-And these assemblies assigned as follows:
+And these assemblies with these types assigned:
 
-- Assembly 1 (type: 12)
-- Assembly 2 (type: 17)
-- Assembly 3 (no type assigned)
+- Assembly 1 (Assembly Type ID: 12)
+- Assembly 2 (Assembly Type ID: 17)
+- Assembly 3 (no Assembly Type assigned)
 
-And, finally, let's imagine we have configured that types "Participation(17)" and "Others(9)" should be in a different main menu than the normal "ASSEMBLIES", called for instance "PARTICIPATIVE ASSEMBLIES".
+And, finally, let's imagine we have configured that types "Participation (17)" and "Others (9)" should be in a different main menu than the normal "ASSEMBLIES", called for instance "PARTICIPATIVE ASSEMBLIES".
 
-Now "Assembly 1" and "Assembly 3" will be listed under the normal "ASSEMBLIES" menu, but "Assembly 2" not.
+Now "Assembly 1" and "Assembly 3" will be listed under the normal "ASSEMBLIES" menu, but "Assembly 2" will not.
 
 Then, another menu item will appear next to "ASSEMBLIES" called "PARTICIPATIVE ASSEMBLIES", when clicking on it, the user will see only the assemblies assigned to types 17 and 9, in this case only the "Assembly 2".
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ Finally, incorrect routes will be automatically redirected to the correct ones.
 
 ### configuration
 
-It is configured via the `secrets.yml` file in a new section `assemblies_types`:
+It is configured via the `secrets.yml` file in a new section `alternative_assembly_types`:
 
 ```yaml
 default: &default
-  assemblies_types:
+  alternative_assembly_types:
     -
       key: organs # used to search a I18n key and a route path
-      position: 2.6
-      types: [17]
+      position_in_menu: 2.6
+      assembly_type_ids: [17]
 ```
 
-- **assemblies_types**: must be an array in YAML format, each entry will correspond to a new entry in the main Decidim menu next to the "ASSEMBLIES" item.
-- **key**: the identifier for the menu and URL path. For instance, if it is `organs` we will have a new menu entry for the url `URL/organs` and the name specified in the I18n key ``bcnencomu.assemblies_types.organs`.
+- **alternative_assembly_types**: must be an array in YAML format, each entry will correspond to a new entry in the main Decidim menu next to the "ASSEMBLIES" item.
+- **key**: the identifier for the menu and URL path. For instance, if it is `organs` we will have a new menu entry for the url `<host>/organs` and the name specified in the I18n key ``bcnencomu.alternative_assembly_types.organs`.
 - **position**: Where to place the item in the main menu, the usual "ASSEMBLIES" item have the value `2.5`, lower this number will put it before and vice-versa.
 - **types**: and array of IDs for the model `Decidim::AssembliesType`. All assemblies assigned to this ID will be listed here and not in the normal "ASSEMBLIES" menu.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,46 @@ user.save!
 6. Fill the rest of the form and submit it.
 
 You're good to go!
+
+## The Assembly duplicator hack
+
+PR #15 introduces an experimental feature that allows to duplicate the Assembly module in the menu.
+It uses the Assemblies types to divide the assemblies assigned depending on how it is configured.
+
+For instance, imagine you have these assembly types:
+
+- Governance [type ID: 12]
+- Participation [type ID: 17]
+- Others [type ID: 9]
+
+And these assemblies assigned as follows:
+
+- Assembly 1 (type: 12)
+- Assembly 2 (type: 17)
+- Assembly 3 (no type assigned)
+
+And, finally, let's imagine we have configured that types "Participation(17)" and "Others(9)" should be in a different main menu than the normal "ASSEMBLIES", called for instance "PARTICIPATIVE ASSEMBLIES". 
+
+Now "Assembly 1" and "Assembly 3" will be listed under the normal "ASSEMBLIES" menu, but "Assembly 2" not.
+
+Then, another menu item will appear next to "ASSEMBLIES" called "PARTICIPATIVE ASSEMBLIES", when clicking on it, the user will see only the assemblies assigned to types 17 and 9, in this case only the "Assembly 2".
+
+Finally, incorrect routes will be automatically redirected to the correct ones.
+
+### configuration
+
+It is configured via the `secrets.yml` file in a new section `assemblies_types`:
+
+```yaml
+default: &default
+  assemblies_types:
+    - 
+      key: organs # used to search a I18n key and a route path
+      position: 2.6
+      types: [17]
+```
+
+- **assemblies_types**: must be an array in YAML format, each entry will correspond to a new entry in the main Decidim menu next to the "ASSEMBLIES" item.
+- **key**: the identifier for the menu and URL path. For instance, if it is `organs` we will have a new menu entry for the url `URL/organs` and the name specified in the I18n key ``bcnencomu.assemblies_types.organs`.
+- **position**: Where to place the item in the main menu, the usual "ASSEMBLIES" item have the value `2.5`, lower this number will put it before and vice-versa.
+- **types**: and array of IDs for the model `Decidim::AssembliesType`. All assemblies assigned to this ID will be listed here and not in the normal "ASSEMBLIES" menu.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And these assemblies assigned as follows:
 - Assembly 2 (type: 17)
 - Assembly 3 (no type assigned)
 
-And, finally, let's imagine we have configured that types "Participation(17)" and "Others(9)" should be in a different main menu than the normal "ASSEMBLIES", called for instance "PARTICIPATIVE ASSEMBLIES". 
+And, finally, let's imagine we have configured that types "Participation(17)" and "Others(9)" should be in a different main menu than the normal "ASSEMBLIES", called for instance "PARTICIPATIVE ASSEMBLIES".
 
 Now "Assembly 1" and "Assembly 3" will be listed under the normal "ASSEMBLIES" menu, but "Assembly 2" not.
 
@@ -57,7 +57,7 @@ It is configured via the `secrets.yml` file in a new section `assemblies_types`:
 ```yaml
 default: &default
   assemblies_types:
-    - 
+    -
       key: organs # used to search a I18n key and a route path
       position: 2.6
       types: [17]

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -8,10 +8,10 @@
 # requested assembly belongs into another scope:
 # (e.g `assemblies/alternative-assembly-slug` > `alternative/alternative-assembly-slug`)
 class AssembliesScoper
-  def self.assemblies_types
-    return [] unless Rails.application.secrets.assemblies_types
+  def self.alternative_assembly_types
+    return [] unless Rails.application.secrets.alternative_assembly_types
 
-    Rails.application.secrets.assemblies_types
+    Rails.application.secrets.alternative_assembly_types
   end
 
   def initialize(app)
@@ -48,7 +48,7 @@ class AssembliesScoper
   private
 
   def types
-    AssembliesScoper.assemblies_types.map { |item| [item[:key], item[:types]] }.to_h
+    AssembliesScoper.alternative_assembly_types.map { |item| [item[:key], item[:types]] }.to_h
   end
 
   def type_for(type_id)

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -48,7 +48,7 @@ class AssembliesScoper
   private
 
   def types
-    AssembliesScoper.alternative_assembly_types.map { |item| [item[:key], item[:types]] }.to_h
+    AssembliesScoper.alternative_assembly_types.map { |item| [item[:key], item[:assembly_type_ids]] }.to_h
   end
 
   def type_for(type_id)

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -6,13 +6,19 @@
 #  TODO: configure from secrets.yml
 # Also redirects individual assemblies to the proper url i the slug is under the wrong prefix
 class AssembliesScoper
+  def self.assemblies_types
+    return [] unless Rails.application.secrets.assemblies_types
+
+    Rails.application.secrets.assemblies_types
+  end
+
   def initialize(app)
     @app = app
   end
 
   def call(env)
     @types = types
-    return @app.call(env) unless @types
+    return @app.call(env) if @types.blank?
 
     request = Rack::Request.new(env)
     @parts = request.path.split("/")
@@ -40,9 +46,7 @@ class AssembliesScoper
   private
 
   def types
-    return unless Rails.application.secrets.assemblies_types
-
-    Rails.application.secrets.assemblies_types.map { |item| [item[:key], item[:types]] }.to_h
+    AssembliesScoper.assemblies_types.map { |item| [item[:key], item[:types]] }.to_h
   end
 
   def type_for(type_id)

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-# Provides a global scope for the application for knowin when to scope
-# the model Assembly to certain assembly types only
-# Assemblies will be divided in 2, when the URL starts with /assemblies and when start with /organs
-#  TODO: configure from secrets.yml
-# Also redirects individual assemblies to the proper url i the slug is under the wrong prefix
+# Provides a way for the application to scope assemblies depending on their type
+# A url scope will be generated for every alternative assembly type that needs its own
+# section, (e.g `/assemblies` and `/organs`)
+#
+# It also manages redirects for individual assemblies to the proper url path if the
+# requested assembly belongs into another scope:
+# (e.g `assemblies/alternative-assembly-slug` > `alternative/alternative-assembly-slug`)
 class AssembliesScoper
   def self.assemblies_types
     return [] unless Rails.application.secrets.assemblies_types
@@ -26,10 +28,10 @@ class AssembliesScoper
     type_id = current_assembly&.decidim_assemblies_type_id
     type = type_for(type_id)
     if @parts[1] == "assemblies"
-      # redirect to the duplicated assemblies if matches the type
+      # redirect to the alternative assemblies if matches the type
       return redirect(type[0]) if @types.values.flatten.include?(type_id)
 
-      # just exclude all types specified to duplicate
+      # just exclude all types specified as alternative
       Decidim::Assembly.scope_to_types(@types.values.flatten, :exclude)
     elsif @parts[1] && @types[@parts[1]]
       # redirect to assemblies if not matches the type

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class AssembliesScoper
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @types = [4]
+    request = Rack::Request.new(env)
+    @parts = request.path.split("/")
+
+    case @parts[1]
+    when "assemblies"
+      Decidim::Assembly.scope_to_types(@types, :exclude)
+      # redirect to organs if matches the type
+      if @types.include?(assembly&.decidim_assemblies_type_id)
+        return [301, { "Location" => location("organs"), "Content-Type" => "text/html", "Content-Length" => "0" }, []]
+      end
+
+    when "organs"
+      Decidim::Assembly.scope_to_types(@types, :include) 
+      # redirect to assemblies if not matches the type
+      if @types.exclude?(assembly&.decidim_assemblies_type_id)
+        return [301, { "Location" => location("assemblies"), "Content-Type" => "text/html", "Content-Length" => "0" }, []]
+      end
+    end
+    Decidim::Assembly.scope_to_types(nil, nil)
+    @app.call(env)
+  end
+
+  private
+
+  def assembly
+    Decidim::Assembly.unscoped.find_by(slug: @parts[2])
+  end
+
+  def location(prefix)
+    parts = @parts
+    parts[1] = prefix
+    parts.join("/")
+  end
+end

--- a/app/middleware/assemblies_scoper.rb
+++ b/app/middleware/assemblies_scoper.rb
@@ -14,16 +14,12 @@ class AssembliesScoper
     when "assemblies"
       Decidim::Assembly.scope_to_types(@types, :exclude)
       # redirect to organs if matches the type
-      if @types.include?(assembly&.decidim_assemblies_type_id)
-        return [301, { "Location" => location("organs"), "Content-Type" => "text/html", "Content-Length" => "0" }, []]
-      end
+      return [301, { "Location" => location("organs"), "Content-Type" => "text/html", "Content-Length" => "0" }, []] if @types.include?(assembly&.decidim_assemblies_type_id)
 
     when "organs"
-      Decidim::Assembly.scope_to_types(@types, :include) 
+      Decidim::Assembly.scope_to_types(@types, :include)
       # redirect to assemblies if not matches the type
-      if @types.exclude?(assembly&.decidim_assemblies_type_id)
-        return [301, { "Location" => location("assemblies"), "Content-Type" => "text/html", "Content-Length" => "0" }, []]
-      end
+      return [301, { "Location" => location("assemblies"), "Content-Type" => "text/html", "Content-Length" => "0" }, []] if @types.exclude?(assembly&.decidim_assemblies_type_id)
     end
     Decidim::Assembly.scope_to_types(nil, nil)
     @app.call(env)

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -31,11 +31,15 @@ end
 
 Rails.application.config.after_initialize do
   # Creates a new menu next to Assemblies for /organs
-  Decidim.menu :menu do |menu|
-    menu.item "Organs",
-              Rails.application.routes.url_helpers.organs_path,
-              position: 2.4,
-              if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: [4]).published.any?,
-              active: :inclusive
+  if Rails.application.secrets.assemblies_types
+    Rails.application.secrets.assemblies_types.each do |item|
+      Decidim.menu :menu do |menu|
+        menu.item I18n.t(item[:key], scope: "bcnencomu.assemblies_types"),
+                  Rails.application.routes.url_helpers.send("#{item[:key]}_path"),
+                  position: item[:position],
+                  if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:types]).published.any?,
+                  active: :inclusive
+      end
+    end
   end
 end

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Rails.configuration.middleware.use AssembliesScoper
+Rails.application.config.to_prepare do
+  Decidim::Assembly.class_eval do
+
+    class << self
+      attr_accessor :scope_types, :scope_types_mode
+
+      def scope_to_types(types, mode)
+        self.scope_types = types
+        self.scope_types_mode = mode
+      end
+    end
+
+    def self.default_scope
+      return unless scope_types
+
+      case scope_types_mode
+      when :exclude
+        where("decidim_assemblies_type_id IS NULL OR decidim_assemblies_type_id NOT IN (?)", scope_types)
+      when :include
+        where("decidim_assemblies_type_id IN (?)", scope_types)
+      end
+    end
+  end
+end

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -36,7 +36,7 @@ Rails.application.config.after_initialize do
       menu.item I18n.t(item[:key], scope: "bcnencomu.alternative_assembly_types"),
                 Rails.application.routes.url_helpers.send("#{item[:key]}_path"),
                 position: item[:position_in_menu],
-                if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:types]).published.any?,
+                if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:assembly_type_ids]).published.any?,
                 active: :inclusive
     end
   end

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+# this middleware will detect by the URL if all calls to Assembly need to skip (or include) certain types
 Rails.configuration.middleware.use AssembliesScoper
+
+# tampers the Assembly model to put a default scope in all queries
+# if configured previously
 Rails.application.config.to_prepare do
   Decidim::Assembly.class_eval do
     class << self
@@ -22,5 +26,16 @@ Rails.application.config.to_prepare do
         where("decidim_assemblies_type_id IN (?)", scope_types)
       end
     end
+  end
+end
+
+Rails.application.config.after_initialize do
+  # Creates a new menu next to Assemblies for /organs
+  Decidim.menu :menu do |menu|
+    menu.item "Organs",
+              Rails.application.routes.url_helpers.organs_path,
+              position: 2.4,
+              if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: [4]).published.any?,
+              active: :inclusive
   end
 end

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -3,7 +3,6 @@
 Rails.configuration.middleware.use AssembliesScoper
 Rails.application.config.to_prepare do
   Decidim::Assembly.class_eval do
-
     class << self
       attr_accessor :scope_types, :scope_types_mode
 

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -30,16 +30,14 @@ Rails.application.config.to_prepare do
 end
 
 Rails.application.config.after_initialize do
-  # Creates a new menu next to Assemblies for /organs
-  if Rails.application.secrets.assemblies_types
-    Rails.application.secrets.assemblies_types.each do |item|
-      Decidim.menu :menu do |menu|
-        menu.item I18n.t(item[:key], scope: "bcnencomu.assemblies_types"),
-                  Rails.application.routes.url_helpers.send("#{item[:key]}_path"),
-                  position: item[:position],
-                  if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:types]).published.any?,
-                  active: :inclusive
-      end
+  # Creates a new menu next to Assemblies for every type configured
+  AssembliesScoper.assemblies_types.each do |item|
+    Decidim.menu :menu do |menu|
+      menu.item I18n.t(item[:key], scope: "bcnencomu.assemblies_types"),
+                Rails.application.routes.url_helpers.send("#{item[:key]}_path"),
+                position: item[:position],
+                if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:types]).published.any?,
+                active: :inclusive
     end
   end
 end

--- a/config/initializers/assemblies_default_type_scopes.rb
+++ b/config/initializers/assemblies_default_type_scopes.rb
@@ -31,11 +31,11 @@ end
 
 Rails.application.config.after_initialize do
   # Creates a new menu next to Assemblies for every type configured
-  AssembliesScoper.assemblies_types.each do |item|
+  AssembliesScoper.alternative_assembly_types.each do |item|
     Decidim.menu :menu do |menu|
-      menu.item I18n.t(item[:key], scope: "bcnencomu.assemblies_types"),
+      menu.item I18n.t(item[:key], scope: "bcnencomu.alternative_assembly_types"),
                 Rails.application.routes.url_helpers.send("#{item[:key]}_path"),
-                position: item[:position],
+                position: item[:position_in_menu],
                 if: Decidim::Assembly.unscoped.where(organization: current_organization, assembly_type: item[:types]).published.any?,
                 active: :inclusive
     end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,4 +1,7 @@
 ca:
+  bcnencomu:
+    assemblies_types:
+      organs: Òrgans
   activemodel:
     attributes:
       question:
@@ -32,6 +35,8 @@ ca:
       question_header:
         back_to_question: 'Torna a la pregunta'
   decidim:
+    menu:
+      assemblies: Espais participatius
     debates:
       actions:
         active: Debats actius

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -36,7 +36,7 @@ ca:
         back_to_question: 'Torna a la pregunta'
   decidim:
     menu:
-      assemblies: Espais participatius
+      assemblies: Espais de participació
     debates:
       actions:
         active: Debats actius

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,6 +1,6 @@
 ca:
   bcnencomu:
-    assemblies_types:
+    alternative_assembly_types:
       organs: Òrgans
   activemodel:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  hello: Hello world

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -36,7 +36,7 @@ es:
         back_to_question: 'Volver a la pregunta'
   decidim:
     menu:
-      assemblies: Espacios participativos
+      assemblies: Espacios de participación
     debates:
       actions:
         active: Detabes activos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,7 @@
 es:
+  bcnencomu:
+    assemblies_types:
+      organs: Órganos
   activemodel:
     attributes:
       question:
@@ -32,6 +35,8 @@ es:
       question_header:
         back_to_question: 'Volver a la pregunta'
   decidim:
+    menu:
+      assemblies: Espacios participativos
     debates:
       actions:
         active: Detabes activos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,6 @@
 es:
   bcnencomu:
-    assemblies_types:
+    alternative_assembly_types:
       organs: Órganos
   activemodel:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,9 @@ Rails.application.routes.draw do
              }
 
   mount Decidim::Core::Engine => "/"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
+  # recreates the /assemblies route for /organs, reusing the same controllers
+  # content will be differentiatied automatically by scoping selectively all SQL queries depending on the URL prefix
   resources :organs, only: [:index, :show], param: :slug, path: "organs", controller: "decidim/assemblies/assemblies" do
     resources :assembly_members, only: :index, path: "members"
     resource :assembly_widget, only: :show, path: "embed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,19 @@ Rails.application.routes.draw do
 
   mount Decidim::Core::Engine => "/"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resources :organs, only: [:index, :show], param: :slug, path: "organs", controller: "decidim/assemblies/assemblies" do
+    resources :assembly_members, only: :index, path: "members"
+    resource :assembly_widget, only: :show, path: "embed"
+  end
+
+  scope "/organs/:assembly_slug/f/:component_id" do
+    Decidim.component_manifests.each do |manifest|
+      next unless manifest.engine
+
+      constraints Decidim::Assemblies::CurrentComponent.new(manifest) do
+        mount manifest.engine, at: "/", as: "decidim_assembly_#{manifest.name}"
+      end
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,19 +25,23 @@ Rails.application.routes.draw do
 
   mount Decidim::Core::Engine => "/"
 
-  # recreates the /assemblies route for /organs, reusing the same controllers
+  # recreates the /assemblies route for /any-alternative, reusing the same controllers
   # content will be differentiatied automatically by scoping selectively all SQL queries depending on the URL prefix
-  resources :organs, only: [:index, :show], param: :slug, path: "organs", controller: "decidim/assemblies/assemblies" do
-    resources :assembly_members, only: :index, path: "members"
-    resource :assembly_widget, only: :show, path: "embed"
-  end
+  if Rails.application.secrets.assemblies_types
+    Rails.application.secrets.assemblies_types.each do |item|
+      resources item[:key], only: [:index, :show], param: :slug, path: item[:key], controller: "decidim/assemblies/assemblies" do
+        resources :assembly_members, only: :index, path: "members"
+        resource :assembly_widget, only: :show, path: "embed"
+      end
 
-  scope "/organs/:assembly_slug/f/:component_id" do
-    Decidim.component_manifests.each do |manifest|
-      next unless manifest.engine
+      scope "/#{item[:key]}/:assembly_slug/f/:component_id" do
+        Decidim.component_manifests.each do |manifest|
+          next unless manifest.engine
 
-      constraints Decidim::Assemblies::CurrentComponent.new(manifest) do
-        mount manifest.engine, at: "/", as: "decidim_assembly_#{manifest.name}"
+          constraints Decidim::Assemblies::CurrentComponent.new(manifest) do
+            mount manifest.engine, at: "/", as: "decidim_assembly_#{manifest.name}"
+          end
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,8 @@ Rails.application.routes.draw do
 
   # recreates the /assemblies route for /any-alternative, reusing the same controllers
   # content will be differentiatied automatically by scoping selectively all SQL queries depending on the URL prefix
-  if Rails.application.secrets.assemblies_types
-    Rails.application.secrets.assemblies_types.each do |item|
+  if Rails.application.secrets.alternative_assembly_types
+    Rails.application.secrets.alternative_assembly_types.each do |item|
       resources item[:key], only: [:index, :show], param: :slug, path: item[:key], controller: "decidim/assemblies/assemblies" do
         resources :assembly_members, only: :index, path: "members"
         resource :assembly_widget, only: :show, path: "embed"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -69,7 +69,7 @@ production:
     - 
       key: organs # used to search a I18n key and a route path
       position_in_menu: 2.6
-      assembly_type_ids: [18]
+      assembly_type_ids: [18,19] # encomuparticipa & test.encomuparticipa
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   smtp_username: <%= ENV["SMTP_USERNAME"] %>
   smtp_password: <%= ENV["SMTP_PASSWORD"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,11 +11,11 @@
 # if you're sharing your code publicly.
 
 default: &default
-  assemblies_types:
+  alternative_assembly_types:
     - 
       key: organs # used to search a I18n key and a route path
-      position: 2.6
-      types: [17]
+      position_in_menu: 2.6
+      assembly_type_ids: [17]
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
   omniauth:
@@ -65,7 +65,7 @@ test:
 # instead read values from the environment.
 production:
   <<: *default
-  assemblies_types:
+  alternative_assembly_types:
     - 
       key: organs # used to search a I18n key and a route path
       position: 2.6

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,6 +11,11 @@
 # if you're sharing your code publicly.
 
 default: &default
+  assemblies_types:
+    - 
+      key: organs # used to search a I18n key and a route path
+      position: 2.6
+      types: [17]
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
   omniauth:
@@ -60,6 +65,11 @@ test:
 # instead read values from the environment.
 production:
   <<: *default
+  assemblies_types:
+    - 
+      key: organs # used to search a I18n key and a route path
+      position: 2.6
+      types: [18]
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   smtp_username: <%= ENV["SMTP_USERNAME"] %>
   smtp_password: <%= ENV["SMTP_PASSWORD"] %>

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -47,6 +47,15 @@ checksums = [
       "/app/controllers/decidim/consultations/admin/responses_controller.rb" => "b8a63f442dd146f1ea3596d485ea29f7",
       "/app/forms/decidim/consultations/multi_vote_form.rb" => "fc2160f0b5e85c9944d652b568c800f3"
     }
+  },
+  {
+    package: "decidim-assemblies",
+    files: {
+      # just to take into the account if some routes change
+      "/lib/decidim/assemblies/engine.rb" => "99a665d60c949c30a7f127c322dc3de5",
+      "/lib/decidim/assemblies/admin_engine.rb" => "15bfba31a46f70870da42a07b588e59d",
+      "/app/models/decidim/assembly.rb" => "b99256774db6151d5b0e47cacdbea550"
+    }
   }
 ]
 

--- a/spec/middleware/assemblies_scoper_spec.rb
+++ b/spec/middleware/assemblies_scoper_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe AssembliesScoper do
+  let(:app) { ->(env) { [200, env, "app"] } }
+  let(:env) { Rack::MockRequest.env_for("https://#{host}/#{path}?foo=bar", "decidim.current_organization" => organization) }
+  let(:host) { "city.domain.org" }
+  let(:middleware) { described_class.new(app) }
+  let(:path) { "some_path" }
+  let!(:organization) { create(:organization, host: host) }
+  let!(:organization2) { create(:organization, host: "another.host.org") }
+  let(:alternative_type) { create :assemblies_type }
+  let(:normal_type) { create :assemblies_type }
+  let!(:external_assembly) { create(:assembly, slug: "external-slug1", organization: organization2) }
+  let!(:external_assembly2) { create(:assembly, slug: "slug2", organization: organization2) }
+  let!(:alternative_assembly) { create(:assembly, slug: "slug1", assembly_type: alternative_type, organization: organization) }
+  let!(:assembly1) { create(:assembly, slug: "slug2", assembly_type: normal_type, organization: organization) }
+  let!(:assembly2) { create(:assembly, slug: "slug3", assembly_type: nil, organization: organization) }
+
+  let(:route) { "alternative_assemblies" }
+  let(:types) { [alternative_type.id] }
+  let(:alternative_assembly_types) do
+    [
+      {
+        key: route,
+        assembly_type_ids: types
+      }
+    ]
+  end
+
+  before do
+    Decidim::Assembly.scope_to_types(nil, nil)
+    allow(AssembliesScoper).to receive(:alternative_assembly_types).and_return(alternative_assembly_types)
+  end
+
+  shared_examples "same environment" do
+    it "do not modify the environment" do
+      code, new_env = middleware.call(env)
+
+      expect(new_env).to eq(env)
+      expect(code).to eq(200)
+    end
+
+    it "has current organization in env" do
+      _code, new_env = middleware.call(env)
+
+      expect(new_env["decidim.current_organization"]).to eq(env["decidim.current_organization"])
+    end
+  end
+
+  shared_examples "untampered assembly model" do
+    it "assembly model is not tampered" do
+      # ensure model is always reset after calling the middleware
+      Decidim::Assembly.scope_to_types([123], :include)
+      middleware.call(env)
+
+      expect(Decidim::Assembly.scope_types).not_to be_present
+      expect(Decidim::Assembly.scope_types_mode).not_to be_present
+    end
+  end
+
+  shared_examples "unaffected routes" do
+    context "when path is the home" do
+      let(:path) { "" }
+
+      it_behaves_like "same environment"
+      it_behaves_like "untampered assembly model"
+    end
+
+    context "when path any other" do
+      let(:path) { "another_path" }
+
+      it_behaves_like "same environment"
+      it_behaves_like "untampered assembly model"
+    end
+  end
+
+  shared_examples "exclude types" do
+    it_behaves_like "same environment"
+
+    it "assembly model is tampered with exclude types" do
+      middleware.call(env)
+
+      expect(Decidim::Assembly.scope_types).to eq(types)
+      expect(Decidim::Assembly.scope_types_mode).to eq(:exclude)
+    end
+
+    it "assembly queries only non-specified types" do
+      middleware.call(env)
+
+      expect(Decidim::Assembly.find_by(id: alternative_assembly.id)).not_to be_present
+      expect(Decidim::Assembly.find_by(id: assembly1.id)).to eq(assembly1)
+      expect(Decidim::Assembly.find_by(id: assembly2.id)).to eq(assembly2)
+    end
+  end
+
+  shared_examples "include types" do
+    it_behaves_like "same environment"
+
+    it "assembly model is tampered with include types" do
+      middleware.call(env)
+
+      expect(Decidim::Assembly.scope_types).to eq(types)
+      expect(Decidim::Assembly.scope_types_mode).to eq(:include)
+    end
+
+    it "assembly queries only specified types" do
+      middleware.call(env)
+
+      expect(Decidim::Assembly.find_by(id: alternative_assembly.id)).to eq(alternative_assembly)
+      expect(Decidim::Assembly.find_by(id: assembly1.id)).not_to be_present
+      expect(Decidim::Assembly.find_by(id: assembly2.id)).not_to be_present
+    end
+  end
+
+  context "when no alternative types" do
+    let(:alternative_assembly_types) { [] }
+
+    it_behaves_like "unaffected routes"
+  end
+
+  context "when alternative types" do
+    it_behaves_like "unaffected routes"
+
+    context "and assemblies index" do
+      let(:path) { "assemblies" }
+
+      it_behaves_like "exclude types"
+    end
+
+    context "and assemblies alternative index" do
+      let(:path) { route }
+
+      it_behaves_like "include types"
+    end
+
+    context "and correct assembly" do
+      let(:path) { "assemblies/#{assembly1.slug}" }
+
+      it_behaves_like "exclude types"
+
+      it "do not redirect" do
+        code, new_env = middleware.call(env)
+
+        expect(new_env["Location"]).not_to be_present
+        expect(code).to eq(200)
+      end
+    end
+
+    context "and incorrect assembly" do
+      let(:path) { "assemblies/#{alternative_assembly.slug}" }
+
+      it_behaves_like "untampered assembly model"
+
+      it "redirects" do
+        code, new_env = middleware.call(env)
+
+        expect(new_env["Location"]).to eq("/#{route}/#{alternative_assembly.slug}")
+        expect(code).to eq(301)
+      end
+    end
+
+    context "and correct alternative assembly" do
+      let(:path) { "#{route}/#{alternative_assembly.slug}" }
+
+      it_behaves_like "include types"
+
+      it "do not redirect" do
+        code, new_env = middleware.call(env)
+
+        expect(new_env["Location"]).not_to be_present
+        expect(code).to eq(200)
+      end
+    end
+
+    context "and incorrect alternative assembly" do
+      let(:path) { "#{route}/#{assembly2.slug}" }
+
+      it_behaves_like "untampered assembly model"
+
+      it "redirects" do
+        code, new_env = middleware.call(env)
+
+        expect(new_env["Location"]).to eq("/assemblies/#{assembly2.slug}")
+        expect(code).to eq(301)
+      end
+    end
+
+    context "when assembly from other organization" do
+      let(:path) { "assemblies/#{external_assembly.slug}" }
+
+      it_behaves_like "same environment"
+      it_behaves_like "untampered assembly model"
+
+      it "assembly is not found" do
+        _code, _new_env = middleware.call(env)
+
+        expect(middleware.send(:assembly)).not_to be_present
+      end
+    end
+  end
+end

--- a/spec/models/assembly_spec.rb
+++ b/spec/models/assembly_spec.rb
@@ -10,7 +10,7 @@ module Decidim
     let(:type2) { create :assemblies_type }
     let!(:assembly1) { create(:assembly, slug: "slug1", assembly_type: type1) }
     let!(:assembly2) { create(:assembly, slug: "slug2", assembly_type: type2) }
-    let!(:assembly3) { create(:assembly, slug: "slug2", assembly_type: nil) }
+    let!(:assembly3) { create(:assembly, slug: "slug3", assembly_type: nil) }
 
     it "assemblies have types assigned" do
       expect(assembly1.decidim_assemblies_type_id).to eq(type1.id)

--- a/spec/models/assembly_spec.rb
+++ b/spec/models/assembly_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  describe Assembly do
+    subject { assembly }
+
+    let(:type1) { create :assemblies_type }
+    let(:type2) { create :assemblies_type }
+    let!(:assembly1) { create(:assembly, slug: "slug1", assembly_type: type1) }
+    let!(:assembly2) { create(:assembly, slug: "slug2", assembly_type: type2) }
+    let!(:assembly3) { create(:assembly, slug: "slug2", assembly_type: nil) }
+
+    it "assemblies have types assigned" do
+      expect(assembly1.decidim_assemblies_type_id).to eq(type1.id)
+      expect(assembly2.decidim_assemblies_type_id).to eq(type2.id)
+      expect(assembly3.decidim_assemblies_type_id).to eq(nil)
+    end
+
+    context "when no scope types" do
+      before do
+        Assembly.scope_to_types(nil, nil)
+      end
+
+      it "has no default scope" do
+        expect(Assembly.default_scope).to eq(nil)
+        expect(Assembly.scope_types).to eq(nil)
+        expect(Assembly.scope_types_mode).to eq(nil)
+      end
+
+      it "find all assemblies" do
+        assemblies = Assembly.all
+        expect(assemblies).to include(assembly1)
+        expect(assemblies).to include(assembly2)
+        expect(assemblies).to include(assembly3)
+      end
+    end
+
+    context "when scope types are in :include mode" do
+      before do
+        Assembly.scope_to_types([type1.id], :include)
+      end
+
+      it "has a default scope" do
+        expect(Assembly.default_scope).not_to eq(nil)
+        expect(Assembly.scope_types).to eq([type1.id])
+        expect(Assembly.scope_types_mode).to eq(:include)
+      end
+
+      it "find only included assemblies" do
+        assemblies = Assembly.all
+        expect(assemblies).to include(assembly1)
+        expect(assemblies).not_to include(assembly2)
+        expect(assemblies).not_to include(assembly3)
+      end
+    end
+
+    context "when scope types are in :exclude mode" do
+      before do
+        Assembly.scope_to_types([type2.id], :exclude)
+      end
+
+      it "has a default scope" do
+        expect(Assembly.default_scope).not_to eq(nil)
+        expect(Assembly.scope_types).to eq([type2.id])
+        expect(Assembly.scope_types_mode).to eq(:exclude)
+      end
+
+      it "find only non-included assemblies" do
+        assemblies = Assembly.all
+        expect(assemblies).to include(assembly1)
+        expect(assemblies).not_to include(assembly2)
+        expect(assemblies).to include(assembly3)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,11 +96,11 @@ RSpec.configure do |config|
   config.order = :random
 
   config.before do
-    I18n.available_locales = [:en, :es, :pl, :hu, :pt, :de, :fi, :it, :nl]
-    I18n.default_locale = :en
-    I18n.locale = :en
-    Decidim.available_locales = [:en, :es, :pl, :hu, :pt, :de, :fi, :it, :nl]
-    Decidim.default_locale = :en
+    I18n.available_locales = [:es, :ca, :en]
+    I18n.default_locale = :ca
+    I18n.locale = :ca
+    Decidim.available_locales = [:es, :ca]
+    Decidim.default_locale = :ca
     Capybara.server = :puma
   end
 end

--- a/spec/system/assemblies_spec.rb
+++ b/spec/system/assemblies_spec.rb
@@ -33,7 +33,7 @@ describe "Visit assemblies", type: :system do
       visit decidim.root_path
     end
 
-    it "shows the normal assembly menu" do
+    it "shows the original assembly menu" do
       within ".main-nav" do
         expect(page).to have_content("Espais participatius")
         expect(page).to have_link(href: "/assemblies")
@@ -47,7 +47,7 @@ describe "Visit assemblies", type: :system do
       end
     end
 
-    context "and navigating to normal assemblies" do
+    context "and navigating to original assemblies" do
       before do
         within ".main-nav" do
           click_link "Espais participatius"
@@ -56,7 +56,7 @@ describe "Visit assemblies", type: :system do
 
       it "shows assemblies without excluded types" do
         within "#parent-assemblies" do
-          expect(page).not_to have_content(duplicated_assembly.title["ca"])
+          expect(page).not_to have_content(alternative_assembly.title["ca"])
           expect(page).to have_content(assembly2.title["ca"])
           expect(page).to have_content(assembly.title["ca"])
         end
@@ -67,7 +67,7 @@ describe "Visit assemblies", type: :system do
       end
     end
 
-    context "and navigating to duplicated assemblies" do
+    context "and navigating to alternative assemblies" do
       before do
         within ".main-nav" do
           click_link "Òrgans"
@@ -76,44 +76,44 @@ describe "Visit assemblies", type: :system do
 
       it "shows assemblies without excluded types" do
         within "#parent-assemblies" do
-          expect(page).to have_content(duplicated_assembly.title["ca"])
+          expect(page).to have_content(alternative_assembly.title["ca"])
           expect(page).not_to have_content(assembly2.title["ca"])
           expect(page).not_to have_content(assembly.title["ca"])
         end
       end
 
-      it "has the duplicated path" do
+      it "has the alternative path" do
         expect(page).to have_current_path organs_path
       end
     end
   end
 
-  context "when accessing normal assemblies with the wrong path" do
+  context "when accessing original assemblies with an alternative path" do
     before do
       visit "/organs/#{assembly2.slug}"
     end
 
-    it "redirects to duplicated" do
+    it "redirects to the original path" do
       expect(page).to have_current_path decidim_assemblies.assembly_path(assembly2.slug)
     end
   end
 
-  context "when accessing duplicated assemblies with the wrong path" do
+  context "when accessing alternative assemblies with the original path" do
     before do
-      visit "/assemblies/#{duplicated_assembly.slug}"
+      visit "/assemblies/#{alternative_assembly.slug}"
     end
 
-    it "redirects to normal" do
-      expect(page).to have_current_path organ_path(duplicated_assembly.slug)
+    it "redirects to the alternative path" do
+      expect(page).to have_current_path organ_path(alternative_assembly.slug)
     end
   end
 
-  context "when accessing non typed assemblies with the wrong path" do
+  context "when accessing non typed assemblies with the alternative path" do
     before do
       visit "/organs/#{assembly.slug}"
     end
 
-    it "redirects to duplicated" do
+    it "redirects to the original path" do
       expect(page).to have_current_path decidim_assemblies.assembly_path(assembly.slug)
     end
   end

--- a/spec/system/assemblies_spec.rb
+++ b/spec/system/assemblies_spec.rb
@@ -34,7 +34,7 @@ describe "Visit assemblies", type: :system do
 
     it "shows the original assembly menu" do
       within ".main-nav" do
-        expect(page).to have_content("Espais participatius")
+        expect(page).to have_content("Espais de participació")
         expect(page).to have_link(href: "/assemblies")
       end
     end
@@ -49,7 +49,7 @@ describe "Visit assemblies", type: :system do
     context "and navigating to original assemblies" do
       before do
         within ".main-nav" do
-          click_link "Espais participatius"
+          click_link "Espais de participació"
         end
       end
 

--- a/spec/system/assemblies_spec.rb
+++ b/spec/system/assemblies_spec.rb
@@ -6,25 +6,24 @@ describe "Visit assemblies", type: :system do
   let(:organization) { create :organization }
   let!(:organs) { create :assemblies_type, id: 17 }
   let!(:type2) { create :assemblies_type }
-  let!(:duplicated_assembly) { create(:assembly, slug: "slug1", assembly_type: organs, organization: organization) }
+  let!(:alternative_assembly) { create(:assembly, slug: "slug1", assembly_type: organs, organization: organization) }
   let!(:assembly) { create(:assembly, slug: "slug3", assembly_type: nil, organization: organization) }
   let!(:assembly2) { create(:assembly, slug: "slug2", assembly_type: type2, organization: organization) }
 
   let(:route) { "organs" } # same as defined in secrets.yml!!
   let(:position) { 2.4 }
   let(:types) { [organs.id] }
-  let(:assemblies_types) do
+  let(:alternative_assembly_types) do
     [
       {
         key: route,
-        position: position,
-        types: types
+        position_in_menu: position,
+        assembly_type_ids: types
       }
     ]
   end
 
   before do
-    # allow(AssembliesScoper).to receive(:assemblies_types).and_return(assemblies_types)
     switch_to_host(organization.host)
   end
 

--- a/spec/system/assemblies_spec.rb
+++ b/spec/system/assemblies_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Visit assemblies", type: :system do
+  let(:organization) { create :organization }
+  let!(:organs) { create :assemblies_type, id: 17 }
+  let!(:type2) { create :assemblies_type }
+  let!(:duplicated_assembly) { create(:assembly, slug: "slug1", assembly_type: organs, organization: organization) }
+  let!(:assembly) { create(:assembly, slug: "slug3", assembly_type: nil, organization: organization) }
+  let!(:assembly2) { create(:assembly, slug: "slug2", assembly_type: type2, organization: organization) }
+
+  let(:route) { "organs" } # same as defined in secrets.yml!!
+  let(:position) { 2.4 }
+  let(:types) { [organs.id] }
+  let(:assemblies_types) do
+    [
+      {
+        key: route,
+        position: position,
+        types: types
+      }
+    ]
+  end
+
+  before do
+    # allow(AssembliesScoper).to receive(:assemblies_types).and_return(assemblies_types)
+    switch_to_host(organization.host)
+  end
+
+  context "when visiting home page" do
+    before do
+      visit decidim.root_path
+    end
+
+    it "shows the normal assembly menu" do
+      within ".main-nav" do
+        expect(page).to have_content("Espais participatius")
+        expect(page).to have_link(href: "/assemblies")
+      end
+    end
+
+    it "shows the extra configured menu" do
+      within ".main-nav" do
+        expect(page).to have_content("Òrgans")
+        expect(page).to have_link(href: "/organs")
+      end
+    end
+
+    context "and navigating to normal assemblies" do
+      before do
+        within ".main-nav" do
+          click_link "Espais participatius"
+        end
+      end
+
+      it "shows assemblies without excluded types" do
+        within "#parent-assemblies" do
+          expect(page).not_to have_content(duplicated_assembly.title["ca"])
+          expect(page).to have_content(assembly2.title["ca"])
+          expect(page).to have_content(assembly.title["ca"])
+        end
+      end
+
+      it "has the assemblies path" do
+        expect(page).to have_current_path decidim_assemblies.assemblies_path
+      end
+    end
+
+    context "and navigating to duplicated assemblies" do
+      before do
+        within ".main-nav" do
+          click_link "Òrgans"
+        end
+      end
+
+      it "shows assemblies without excluded types" do
+        within "#parent-assemblies" do
+          expect(page).to have_content(duplicated_assembly.title["ca"])
+          expect(page).not_to have_content(assembly2.title["ca"])
+          expect(page).not_to have_content(assembly.title["ca"])
+        end
+      end
+
+      it "has the duplicated path" do
+        expect(page).to have_current_path organs_path
+      end
+    end
+  end
+
+  context "when accessing normal assemblies with the wrong path" do
+    before do
+      visit "/organs/#{assembly2.slug}"
+    end
+
+    it "redirects to duplicated" do
+      expect(page).to have_current_path decidim_assemblies.assembly_path(assembly2.slug)
+    end
+  end
+
+  context "when accessing duplicated assemblies with the wrong path" do
+    before do
+      visit "/assemblies/#{duplicated_assembly.slug}"
+    end
+
+    it "redirects to normal" do
+      expect(page).to have_current_path organ_path(duplicated_assembly.slug)
+    end
+  end
+
+  context "when accessing non typed assemblies with the wrong path" do
+    before do
+      visit "/organs/#{assembly.slug}"
+    end
+
+    it "redirects to duplicated" do
+      expect(page).to have_current_path decidim_assemblies.assembly_path(assembly.slug)
+    end
+  end
+end

--- a/spec/system/consultations_spec.rb
+++ b/spec/system/consultations_spec.rb
@@ -22,7 +22,7 @@ describe "Visit the consultations main page", type: :system, perform_enqueued: t
   end
 
   it "renders the consultations page" do
-    expect(page).to have_content("2 CONSULTATIONS")
+    expect(page).to have_content("2 CONSULTES")
   end
 
   context "when visiting a consultation" do
@@ -31,7 +31,7 @@ describe "Visit the consultations main page", type: :system, perform_enqueued: t
     end
 
     it "renders the consultation page" do
-      expect(page).to have_content(consultation.title[:en])
+      expect(page).to have_content(consultation.title["ca"])
     end
   end
 
@@ -41,7 +41,7 @@ describe "Visit the consultations main page", type: :system, perform_enqueued: t
     end
 
     it "renders the question page" do
-      expect(page).to have_content(question.title[:en])
+      expect(page).to have_content(question.title["ca"])
     end
   end
 end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -17,7 +17,7 @@ describe "Visit the home page", type: :system do
 
     within ".main-nav" do
       expect(page).to have_content("Inici")
-      expect(page).not_to have_content("Espais participatius")
+      expect(page).not_to have_content("Espais de participació")
       expect(page).not_to have_content("Òrgans")
       expect(page).to have_content("Consultes")
     end
@@ -31,7 +31,7 @@ describe "Visit the home page", type: :system do
 
       within ".main-nav" do
         expect(page).to have_content("Inici")
-        expect(page).to have_content("Espais participatius")
+        expect(page).to have_content("Espais de participació")
         expect(page).not_to have_content("Òrgans")
         expect(page).to have_content("Consultes")
       end
@@ -47,7 +47,7 @@ describe "Visit the home page", type: :system do
 
       within ".main-nav" do
         expect(page).to have_content("Inici")
-        expect(page).to have_content("Espais participatius")
+        expect(page).to have_content("Espais de participació")
         expect(page).to have_content("Òrgans")
         expect(page).to have_content("Consultes")
       end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -5,17 +5,52 @@ require "rails_helper"
 describe "Visit the home page", type: :system do
   let(:organization) { create :organization }
 
+  let!(:organs) { create :assemblies_type, id: 17 }
   let!(:consultation) { create(:consultation, :published, organization: organization) }
-  let!(:assembly) { create(:assembly, :published, organization: organization) }
 
   before do
     switch_to_host(organization.host)
-    visit decidim.root_path
   end
 
-  it "renders the home page" do
-    expect(page).to have_content("Inici")
-    expect(page).to have_content("Espais participatius")
-    expect(page).to have_content("Consultes")
+  it "renders the expected menu" do
+    visit decidim.root_path
+
+    within ".main-nav" do
+      expect(page).to have_content("Inici")
+      expect(page).not_to have_content("Espais participatius")
+      expect(page).not_to have_content("Òrgans")
+      expect(page).to have_content("Consultes")
+    end
+  end
+
+  context "when there is normal assemblies" do
+    let!(:assembly) { create(:assembly, :published, organization: organization) }
+
+    it "renders the expected menu" do
+      visit decidim.root_path
+
+      within ".main-nav" do
+        expect(page).to have_content("Inici")
+        expect(page).to have_content("Espais participatius")
+        expect(page).not_to have_content("Òrgans")
+        expect(page).to have_content("Consultes")
+      end
+    end
+  end
+
+  context "when there is alternative assemblies" do
+    let!(:assembly) { create(:assembly, :published, organization: organization) }
+    let!(:assembly2) { create(:assembly, :published, assembly_type: organs, organization: organization) }
+
+    it "renders the expected menu" do
+      visit decidim.root_path
+
+      within ".main-nav" do
+        expect(page).to have_content("Inici")
+        expect(page).to have_content("Espais participatius")
+        expect(page).to have_content("Òrgans")
+        expect(page).to have_content("Consultes")
+      end
+    end
   end
 end

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -2,15 +2,20 @@
 
 require "rails_helper"
 
-describe "Visit the home page", type: :system, perform_enqueued: true do
+describe "Visit the home page", type: :system do
   let(:organization) { create :organization }
+
+  let!(:consultation) { create(:consultation, :published, organization: organization) }
+  let!(:assembly) { create(:assembly, :published, organization: organization) }
 
   before do
     switch_to_host(organization.host)
+    visit decidim.root_path
   end
 
   it "renders the home page" do
-    visit decidim.root_path
-    expect(page).to have_content("Home")
+    expect(page).to have_content("Inici")
+    expect(page).to have_content("Espais participatius")
+    expect(page).to have_content("Consultes")
   end
 end

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -11,11 +11,11 @@ describe "Visit a proposal", type: :system, perform_enqueued: true do
   before do
     switch_to_host(organization.host)
     page.visit main_component_path(proposals_component)
-    click_link proposal.title["en"]
+    click_link proposal.title["ca"]
   end
 
   it "allows viewing a single proposal" do
-    expect(page).to have_content(proposal.title["en"])
-    expect(page).to have_content(strip_tags(proposal.body["en"]).strip)
+    expect(page).to have_content(proposal.title["ca"])
+    expect(page).to have_content(strip_tags(proposal.body["ca"]).strip)
   end
 end


### PR DESCRIPTION
A pretty wild hack that duplicates the Assembly menu and assigns assemblies to each menu depending on the type

![image](https://user-images.githubusercontent.com/1401520/102497517-04c26000-4079-11eb-8b6d-4b06d4f5d39a.png)

![image](https://user-images.githubusercontent.com/1401520/102497560-1441a900-4079-11eb-9cc6-46e16cc21d4f.png)

Fixes #8 

- [x] hack that scopes the model `Assembly`﻿ depending on the URL.
- [x] Add a second menu
- [x] Configure the scoped assemblies types in secrets.yml
- [x] Add tests
