### PR TITLE
Sidekiq config for exports and user_report queues

### DIFF
--- a/config/sidekiq_worker.yml
+++ b/config/sidekiq_worker.yml
@@ -5,6 +5,7 @@
   - ["newsletters_opt_in", 1]
   - ["decidim_events", 1]
   - ["events", 1]
+  - ["translations", 1]
   - ["user_report", 1]
   - ["metrics", 1]
   - ["default", 1]

--- a/config/sidekiq_worker.yml
+++ b/config/sidekiq_worker.yml
@@ -1,8 +1,10 @@
 :queues:
   - ["mailers", 2]
+  - ["exports", 2]
   - ["newsletter", 1]
   - ["newsletters_opt_in", 1]
   - ["decidim_events", 1]
   - ["events", 1]
+  - ["user_report", 1]
   - ["metrics", 1]
   - ["default", 1]


### PR DESCRIPTION
Add missing sidekiq worker config for `exports` and `user_report` queues


⚠️ Before deploying, please remove unncecessary jobs from the `exports` and `user_report` queues (from `/sidekiq`)