### PR TITLE
Allow GET method for OmniAuth access

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,8 @@ GEM
     multi_xml (0.6.0)
     mustache (1.1.1)
     nio4r (2.5.8)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.10)
@@ -823,6 +825,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -859,4 +862,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.13
+   2.3.18

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.allowed_request_methods = [:get, :post]

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 OmniAuth.config.allowed_request_methods = [:get, :post]


### PR DESCRIPTION
Access from CiviCRM is giving the error `Not found. Authentication passthru.`

To solve it, we allow access to the `/users/auth/civicrm` endpoint with GET and POST methods.

See [Devise, OmniAuth & Facebook: "Not found. Authentication passthru."](https://stackoverflow.com/questions/13812844/devise-omniauth-facebook-not-found-authentication-passthru)