### PR TITLE
Votes have a bonus if a complete group is voted

### DIFF
--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -1,0 +1,42 @@
+<div class="card" id="consultations">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t "decidim.admin.titles.results" %>
+      <span class="label button--title">
+        <%= t "decidim.admin.consultations.results.total_votes", count: current_consultation.total_votes %>
+        /
+        <%= t "decidim.admin.consultations.results.participants", count: current_consultation.total_participants %>
+        </span>
+    </h2>
+  </div>
+  <div class="card-section">
+    <table class="table-list">
+      <% current_consultation.questions.published.includes(:responses).each do |question| %>
+        <% unless question.external_voting %>
+          <thead>
+          <tr>
+            <th><%= strip_tags translated_attribute question.title %></th>
+            <th class="table-list__actions">
+              <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
+              /
+              <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
+            </th>
+          </tr>
+          </thead>
+          <tbody>
+          <% if question.publishable_results? %>
+            <% question.sorted_results.each do |response| %>
+              <tr>
+                <td><%= strip_tags translated_attribute response.title %></td>
+                <td><%= response.weighted_votes_count %></td>
+              </tr>
+            <% end %>
+          <% else %>
+            <tr><td><em><%= t "decidim.admin.consultations.results.not_visible" %></em></td><td>&nbsp;</td></tr>
+          <% end %>
+          </tbody>
+        <% end %>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/decidim/consultations/admin/questions/_form.html.erb
+++ b/app/views/decidim/consultations/admin/questions/_form.html.erb
@@ -1,0 +1,88 @@
+<%= javascript_pack_tag "decidim_consultations" %>
+
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t "questions.form.title", scope: "decidim.admin" %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.translated :editor, :title, toolbar: :full, lines: 5, autofocus: true %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :subtitle %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :promoter_group %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :participatory_scope %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :question_context, toolbar: :full, lines: 25 %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :what_is_decided, toolbar: :full, lines: 25 %>
+    </div>
+
+    <div class="row column">
+      <%= scopes_picker_field form, :decidim_scope_id, root: nil %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :origin_scope %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :origin_title %>
+    </div>
+
+    <div class="row column">
+      <%= form.url_field :origin_url %>
+    </div>
+
+    <div class="row column">
+      <%= form.number_field :order, step: 1, min: 0 %>
+    </div>
+
+    <div class="row column">
+      <%= form.text_field :slug %>
+      <p class="help-text">
+        <%== t "consultations.form.slug_help",
+               scope: "decidim.admin",
+               url: decidim_form_slug_url(:questions, form.object.slug || question_example_slug) %>
+      </p>
+    </div>
+
+    <div class="row column">
+      <%= form.check_box :external_voting %>
+    </div>
+
+    <div class="row column">
+      <%= form.check_box :is_weighted %>
+    </div>
+
+    <div class="row column">
+      <%= form.url_field :i_frame_url %>
+    </div>
+
+    <div class="row">
+      <div class="columns xlarge-4">
+        <%= form.text_field :hashtag %>
+      </div>
+
+      <div class="columns xlarge-4">
+        <%= form.upload :hero_image %>
+      </div>
+
+      <div class="columns xlarge-4">
+        <%= form.upload :banner_image %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/consultations/consultations/_question.html.erb
+++ b/app/views/decidim/consultations/consultations/_question.html.erb
@@ -23,8 +23,8 @@
                 <% if question.most_voted_response.present? %>
                   <span class="button__info"><%= translated_attribute question.most_voted_response.title %></span>
                   <span class="button__info">
-                    <%= question.most_voted_response.votes_count %>
-                    <%= t "consultations.question.votes_out_of", scope: "decidim", count: question.most_voted_response.votes_count %>
+                    <%= question.most_voted_response.weighted_votes_count %>
+                    <%= t "consultations.question.votes_out_of", scope: "decidim", count: question.most_voted_response.weighted_votes_count %>
                     <%= question.total_votes %>
                   </span>
                 <% end %>

--- a/app/views/decidim/consultations/questions/_results.html.erb
+++ b/app/views/decidim/consultations/questions/_results.html.erb
@@ -1,0 +1,18 @@
+<% if question.sorted_results.any? %>
+  <div class=row>
+    <h2 class=section-heading><%= t "questions.results.title", scope: "decidim" %></h2>
+    <% if question.multiple? %>
+      <%= render partial: "decidim/consultations/question_multiple_votes/results_rules", locals: { question: question } %>
+    <% end %>
+    <div class="card card--list">
+      <% question.sorted_results.each do |response| %>
+        <div class=card--list__item>
+          <div class="card--list__text"><%= translated_attribute response.title %></div>
+          <div class="card--list__data">
+            <span class="card--list__data__number"><%= response.weighted_votes_count %></span>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/custom_consultations.rb
+++ b/config/initializers/custom_consultations.rb
@@ -154,6 +154,74 @@ Rails.application.config.to_prepare do
     end
   end
 
+  # /app/commands/decidim/consultations/admin/create_question.rb
+  Decidim::Consultations::Admin::CreateQuestion.class_eval do
+    private
+
+    def create_question
+      question = Decidim::Consultations::Question.new(
+        consultation: form.context.current_consultation,
+        organization: form.context.current_consultation.organization,
+        decidim_scope_id: form.decidim_scope_id,
+        title: form.title,
+        slug: form.slug,
+        subtitle: form.subtitle,
+        what_is_decided: form.what_is_decided,
+        promoter_group: form.promoter_group,
+        participatory_scope: form.participatory_scope,
+        question_context: form.question_context,
+        hashtag: form.hashtag,
+        hero_image: form.hero_image,
+        banner_image: form.banner_image,
+        origin_scope: form.origin_scope,
+        origin_title: form.origin_title,
+        origin_url: form.origin_url,
+        external_voting: form.external_voting,
+        i_frame_url: form.i_frame_url,
+        order: form.order,
+        is_weighted: form.is_weighted
+      )
+
+      return question unless question.valid?
+
+      question.save
+      question
+    end
+  end
+
+  # /app/commands/decidim/consultations/admin/update_question.rb
+  Decidim::Consultations::Admin::UpdateQuestion.class_eval do
+    private
+
+    def attributes
+      {
+        decidim_scope_id: form.decidim_scope_id,
+        title: form.title,
+        subtitle: form.subtitle,
+        slug: form.slug,
+        what_is_decided: form.what_is_decided,
+        promoter_group: form.promoter_group,
+        participatory_scope: form.participatory_scope,
+        question_context: form.question_context,
+        hashtag: form.hashtag,
+        origin_scope: form.origin_scope,
+        origin_title: form.origin_title,
+        origin_url: form.origin_url,
+        external_voting: form.external_voting,
+        i_frame_url: form.i_frame_url,
+        order: form.order,
+        is_weighted: form.is_weighted
+      }.merge(
+        attachment_attributes(:hero_image, :banner_image)
+      )
+    end
+  end
+
+  # /app/forms/decidim/consultations/admin/question_form.rb
+  Decidim::Consultations::Admin::QuestionForm.class_eval do
+    attribute :is_weighted, Virtus::Attribute::Boolean, default: false
+  end
+
   # /app/forms/decidim/consultations/multi_vote_form.rb
   # Admin validation customization
   # Decidim::Consultations::Admin::QuestionConfigurationForm.class_eval do

--- a/config/initializers/custom_consultations.rb
+++ b/config/initializers/custom_consultations.rb
@@ -45,7 +45,7 @@ Rails.application.config.to_prepare do
     end
 
     def weighted_votes_count
-      return votes_count unless response_group.complete_list? && question.is_weighted?
+      return votes_count unless response_group&.complete_list? && question.is_weighted?
 
       votes_count + response_group.complete_votes_count * 0.2
     end

--- a/db/migrate/20230614125229_add_is_weighted_column_in_decidim_consultations_questions_table.rb
+++ b/db/migrate/20230614125229_add_is_weighted_column_in_decidim_consultations_questions_table.rb
@@ -1,0 +1,5 @@
+class AddIsWeightedColumnInDecidimConsultationsQuestionsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_consultations_questions, :is_weighted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_201637) do
+ActiveRecord::Schema.define(version: 2023_06_14_125229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -617,6 +617,7 @@ ActiveRecord::Schema.define(version: 2022_05_16_201637) do
     t.jsonb "instructions"
     t.integer "comments_count", default: 0, null: false
     t.integer "follows_count", default: 0, null: false
+    t.boolean "is_weighted", default: false
     t.index ["decidim_consultation_id"], name: "index_consultations_questions_on_consultation_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_question_slug_and_organization", unique: true
     t.index ["decidim_scope_id"], name: "index_decidim_consultations_questions_on_decidim_scope_id"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -30,6 +30,7 @@ checksums = [
     package: "decidim-consultations",
     files: {
       # views
+      "/app/views/decidim/consultations/admin/consultations/results.html.erb" => "1a2f7afd79b20b1fcf66bdece660e8ae",
       "/app/views/decidim/consultations/admin/question_configuration/_form.html.erb" => "bca0b383e5eac51414cc5c3347fc8227",
       "/app/views/decidim/consultations/admin/responses/_form.html.erb" => "6846d66395457acdd7d6ec839a49b0ec",
       "/app/views/decidim/consultations/consultations/_question.html.erb" => "364d7f8370cdbe7ae70c545fff2e21fa",
@@ -37,6 +38,7 @@ checksums = [
       "/app/views/decidim/consultations/consultations/show.html.erb" => "84a1569b796f724efa304b9dfc40f68a",
       "/app/views/decidim/consultations/question_multiple_votes/_form.html.erb" => "af610283ce7ee20f5ef786228a263d4a",
       "/app/views/decidim/consultations/question_multiple_votes/_voting_rules.html.erb" => "207a85b27ee044bd6f5fa79e4ba9dce9",
+      "/app/views/decidim/consultations/questions/_results.html.erb" => "2d8196efbf23e2ad7b8c32713c28b240",
       "/app/views/decidim/consultations/questions/_vote_button.html.erb" => "a339b7639e8d36b0699ab3f7763872fb",
       "/app/views/decidim/consultations/questions/_vote_modal.html.erb" => "ae7c38afcc6588a00f8298ea69769da7",
       "/app/views/decidim/consultations/questions/show.html.erb" => "db9cbbd5933b17bce7ff93b1ff9ddfb7",

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -31,6 +31,7 @@ checksums = [
     files: {
       # views
       "/app/views/decidim/consultations/admin/consultations/results.html.erb" => "1a2f7afd79b20b1fcf66bdece660e8ae",
+      "/app/views/decidim/consultations/admin/questions/_form.html.erb" => "c55dc301f095ff35d788fd1c72810ac9",
       "/app/views/decidim/consultations/admin/question_configuration/_form.html.erb" => "bca0b383e5eac51414cc5c3347fc8227",
       "/app/views/decidim/consultations/admin/responses/_form.html.erb" => "6846d66395457acdd7d6ec839a49b0ec",
       "/app/views/decidim/consultations/consultations/_question.html.erb" => "364d7f8370cdbe7ae70c545fff2e21fa",
@@ -42,6 +43,11 @@ checksums = [
       "/app/views/decidim/consultations/questions/_vote_button.html.erb" => "a339b7639e8d36b0699ab3f7763872fb",
       "/app/views/decidim/consultations/questions/_vote_modal.html.erb" => "ae7c38afcc6588a00f8298ea69769da7",
       "/app/views/decidim/consultations/questions/show.html.erb" => "db9cbbd5933b17bce7ff93b1ff9ddfb7",
+      # forms
+      "/app/forms/decidim/consultations/admin/question_form.rb" => "ec32922ff3c79bd5e808208f25946ba2",
+      # commands
+      "/app/commands/decidim/consultations/admin/create_question.rb" => "98a78d88f832aa00dcf252b217454174",
+      "/app/commands/decidim/consultations/admin/update_question.rb" => "b3b972ee37c1005a88c30ddc7c9e8b25",
       # assets
       "/app/packs/src/decidim/consultations/utils_multiple.js" => "8ee3b5bfa77b98f9a953357a54770284",
       # classes in initializers/custom_consultations.rb

--- a/spec/system/weighted_consultations_spec.rb
+++ b/spec/system/weighted_consultations_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Multiple question with multiple votes for different responses from different groups", type: :system, perform_enqueued: true do
+  let(:organization) { create :organization }
+  let(:is_weighted) { true }
+  let!(:consultation) { create(:consultation, :published, organization: organization) }
+  let!(:question) { create(:question, :multiple, organization: organization, consultation: consultation, is_weighted: is_weighted, min_votes: 1, max_votes: 4) }
+  let!(:complete_response_group) { create(:response_group, question: question) }
+  let!(:other_complete_response_group) { create(:response_group, question: question) }
+  let!(:incomplete_response_group) { create(:response_group, question: question) }
+  let!(:other_incomplete_response_group) { create(:response_group, question: question) }
+  let!(:another_incomplete_response_group) { create(:response_group, question: question) }
+  let!(:blank_response_group) { create(:response_group, question: question) }
+  let!(:complete_response_a) { create(:response, question: question, response_group: complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 1 Option A" }) }
+  let!(:complete_response_b) { create(:response, question: question, response_group: complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 1 Option B" }) }
+  let!(:complete_response_c) { create(:response, question: question, response_group: complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 1 Option C" }) }
+  let!(:complete_response_d) { create(:response, question: question, response_group: complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 1 Option D -suplent-" }) }
+  let!(:other_complete_response_a) { create(:response, question: question, response_group: other_complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 2 Option A" }) }
+  let!(:other_complete_response_b) { create(:response, question: question, response_group: other_complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 2 Option B" }) }
+  let!(:other_complete_response_c) { create(:response, question: question, response_group: other_complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 2 Option C" }) }
+  let!(:other_complete_response_d) { create(:response, question: question, response_group: other_complete_response_group, title: Decidim::Faker::Localized.localized { "Complete 2 Option D -suplent-" }) }
+  let!(:incomplete_response_a) { create(:response, question: question, response_group: incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 1 Option A" }) }
+  let!(:incomplete_response_b) { create(:response, question: question, response_group: incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 1 Option B" }) }
+  let!(:incomplete_response_c) { create(:response, question: question, response_group: incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 1 Option C" }) }
+  let!(:other_incomplete_response_a) { create(:response, question: question, response_group: other_incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 2 Option A" }) }
+  let!(:other_incomplete_response_b) { create(:response, question: question, response_group: other_incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 2 Option B" }) }
+  let!(:other_incomplete_response_c) { create(:response, question: question, response_group: other_incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 2 Option C -suplent-" }) }
+  let!(:another_incomplete_response_a) { create(:response, question: question, response_group: another_incomplete_response_group, title: Decidim::Faker::Localized.localized { "Incomplete 3 Option A" }) }
+  let!(:blank_response) { create(:response, question: question, response_group: blank_response_group, title: Decidim::Faker::Localized.localized { "-en blanc-" }) }
+  let(:users) { create_list(:user, 22, organization: organization) }
+
+  before do
+    create(:vote, question: question, author: users[0], response: complete_response_a)
+    create(:vote, question: question, author: users[0], response: complete_response_b)
+    create(:vote, question: question, author: users[0], response: complete_response_c)
+    create(:vote, question: question, author: users[0], response: complete_response_d)
+    create(:vote, question: question, author: users[1], response: blank_response)
+    create(:vote, question: question, author: users[2], response: other_complete_response_a)
+    create(:vote, question: question, author: users[2], response: other_complete_response_b)
+    create(:vote, question: question, author: users[2], response: other_complete_response_c)
+    create(:vote, question: question, author: users[2], response: other_complete_response_d)
+    create(:vote, question: question, author: users[3], response: complete_response_a)
+    create(:vote, question: question, author: users[3], response: complete_response_b)
+    create(:vote, question: question, author: users[3], response: complete_response_c)
+    create(:vote, question: question, author: users[3], response: other_complete_response_d)
+    create(:vote, question: question, author: users[4], response: complete_response_a)
+    create(:vote, question: question, author: users[4], response: complete_response_b)
+    create(:vote, question: question, author: users[4], response: complete_response_c)
+    create(:vote, question: question, author: users[5], response: incomplete_response_a)
+    create(:vote, question: question, author: users[5], response: incomplete_response_b)
+    create(:vote, question: question, author: users[5], response: incomplete_response_c)
+    create(:vote, question: question, author: users[6], response: other_incomplete_response_a)
+    create(:vote, question: question, author: users[6], response: other_incomplete_response_b)
+    create(:vote, question: question, author: users[6], response: other_incomplete_response_c)
+    create(:vote, question: question, author: users[7], response: incomplete_response_a)
+    create(:vote, question: question, author: users[7], response: incomplete_response_b)
+    create(:vote, question: question, author: users[7], response: other_incomplete_response_c)
+    create(:vote, question: question, author: users[8], response: complete_response_a)
+    create(:vote, question: question, author: users[9], response: complete_response_a)
+    create(:vote, question: question, author: users[9], response: complete_response_b)
+    create(:vote, question: question, author: users[9], response: complete_response_c)
+    create(:vote, question: question, author: users[9], response: complete_response_d)
+    create(:vote, question: question, author: users[10], response: incomplete_response_a)
+    create(:vote, question: question, author: users[11], response: incomplete_response_a)
+    create(:vote, question: question, author: users[12], response: incomplete_response_a)
+    create(:vote, question: question, author: users[13], response: incomplete_response_a)
+    create(:vote, question: question, author: users[14], response: incomplete_response_a)
+    create(:vote, question: question, author: users[15], response: incomplete_response_a)
+    create(:vote, question: question, author: users[16], response: incomplete_response_a)
+    create(:vote, question: question, author: users[17], response: incomplete_response_a)
+    create(:vote, question: question, author: users[18], response: complete_response_a)
+    create(:vote, question: question, author: users[18], response: complete_response_b)
+    create(:vote, question: question, author: users[18], response: complete_response_c)
+    create(:vote, question: question, author: users[18], response: complete_response_d)
+    create(:vote, question: question, author: users[19], response: complete_response_a)
+    create(:vote, question: question, author: users[19], response: complete_response_b)
+    create(:vote, question: question, author: users[19], response: complete_response_c)
+    create(:vote, question: question, author: users[19], response: complete_response_d)
+    create(:vote, question: question, author: users[20], response: complete_response_a)
+    create(:vote, question: question, author: users[20], response: complete_response_b)
+    create(:vote, question: question, author: users[20], response: complete_response_c)
+    create(:vote, question: question, author: users[20], response: complete_response_d)
+    create(:vote, question: question, author: users[21], response: complete_response_a)
+    create(:vote, question: question, author: users[21], response: complete_response_b)
+    create(:vote, question: question, author: users[21], response: complete_response_c)
+    create(:vote, question: question, author: users[21], response: complete_response_d)
+  end
+
+  it "return which list is complete" do
+    expect(complete_response_group.complete_list?).to be true
+    expect(other_complete_response_group.complete_list?).to be true
+    expect(incomplete_response_group.complete_list?).to be false
+    expect(other_incomplete_response_group.complete_list?).to be false
+    expect(blank_response_group.complete_list?).to be false
+  end
+
+  context "when the question is weighted" do
+    it "wins the complete response a due to the bonus of complete responses" do
+      expect(question.most_voted_response).to eq(complete_response_a)
+      expect(question.sorted_results.first).to eq(complete_response_a)
+      expect(question.sorted_results.last).to eq(another_incomplete_response_a)
+    end
+
+    it "returns the votes with bonus for complete lists" do
+      expect(complete_response_a.weighted_votes_count).to eq(10.2)
+      expect(complete_response_b.weighted_votes_count).to eq(9.2)
+      expect(complete_response_c.weighted_votes_count).to eq(9.2)
+      expect(complete_response_d.weighted_votes_count).to eq(7.2)
+      expect(other_complete_response_a.weighted_votes_count).to eq(1.2)
+      expect(other_complete_response_b.weighted_votes_count).to eq(1.2)
+      expect(other_complete_response_c.weighted_votes_count).to eq(1.2)
+      expect(other_complete_response_d.weighted_votes_count).to eq(2.2)
+      expect(incomplete_response_a.weighted_votes_count).to eq(10)
+      expect(incomplete_response_b.weighted_votes_count).to eq(2)
+      expect(incomplete_response_c.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_a.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_b.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_c.weighted_votes_count).to eq(2)
+      expect(another_incomplete_response_a.weighted_votes_count).to eq(0)
+      expect(blank_response.weighted_votes_count).to eq(1)
+    end
+  end
+
+  context "when the question is not weighted" do
+    let(:is_weighted) { false }
+
+    it "wins the incomplete response a because there is no bonus of complete responses" do
+      expect(question.most_voted_response).to eq(incomplete_response_a)
+      expect(question.sorted_results.first).to eq(incomplete_response_a)
+      expect(question.sorted_results.last).to eq(another_incomplete_response_a)
+    end
+
+    it "does not return the votes with bonus for complete lists" do
+      expect(complete_response_a.weighted_votes_count).to eq(9)
+      expect(complete_response_b.weighted_votes_count).to eq(8)
+      expect(complete_response_c.weighted_votes_count).to eq(8)
+      expect(complete_response_d.weighted_votes_count).to eq(6)
+      expect(other_complete_response_a.weighted_votes_count).to eq(1)
+      expect(other_complete_response_b.weighted_votes_count).to eq(1)
+      expect(other_complete_response_c.weighted_votes_count).to eq(1)
+      expect(other_complete_response_d.weighted_votes_count).to eq(2)
+      expect(incomplete_response_a.weighted_votes_count).to eq(10)
+      expect(incomplete_response_b.weighted_votes_count).to eq(2)
+      expect(incomplete_response_c.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_a.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_b.weighted_votes_count).to eq(1)
+      expect(other_incomplete_response_c.weighted_votes_count).to eq(2)
+      expect(another_incomplete_response_a.weighted_votes_count).to eq(0)
+      expect(blank_response.weighted_votes_count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
If a complete group is voted, every response counts as 1.2 instead of 1.

A group is considered complete when its number of responses is the same as the `max_votes` defined in its question and the number of the responses marked as _suplents_ is the same as the `min_votes` defined in its question.

---

The `votes_count` method of the response model keeps untouched. We have created a new `weighted_votes_count` that takes this into account when the value of the column `is_weighted` in the question is true. Some of the views have been changed to take this into account.

---

A complete test has been created with the scenario below:
- A question with multiple responses (4 max votes and 1 min vote)
- 6 groups: 2 of them complete, 3 incomplete, and 1 for blank response
- 22 users voting with the distribution of the votes below:
  - Group 1 (6 complete votes)
    - Response 1: 9 votes
    - Response 2: 8 votes
    - Response 3: 8 votes
    - Response 4: 6 votes
  - Group 2 (1 complete vote)
    - Response 1: 1 vote
    - Response 2: 1 vote
    - Response 3: 1 vote
    - Response 4: 2 votes
  - Group 3
    - Response 1: 10 votes
    - Response 2: 2 votes
    - Response 3: 1 vote
  - Group 4
    - Response 1: 1 vote
    - Response 2: 1 vote
    - Response 3: 2 votes
  - Group 5:
    - Response 1: 0 votes
  - Group 6:
    - Response 1: 1 vote

In this scenario:
- When the question is configured as weighted, the response with the highest score is the first response from the first group with a score of 10.2 (9 votes and 1.2 points of bonus as its group has 6 complete votes).
- When the question is not configured as weighted, the response with the highest score is the first from the third group with 9 votes (as complete group bonus is not being taken into account).